### PR TITLE
feat: add flag implementation with appropriate test

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -209,7 +209,12 @@ pub fn run_v2() -> Result<(), Box<dyn Error>> {
                 )?
                 .deserialize_input::<Cluster>()?
                 .print_input()
-                .try_map(|IO { input, output }| {
+                .try_map(|IO { mut input, output }| {
+                    if args.get_flag("fd-as-zone") {
+                        input
+                            .iter_mut()
+                            .for_each(Cluster::use_failure_domain_as_zone_for_instances);
+                    }
                     Inventory::try_from(&input).map(|inventory| IO {
                         input: Some(inventory),
                         output,

--- a/src/task/args.rs
+++ b/src/task/args.rs
@@ -67,6 +67,12 @@ pub(super) fn read() -> ArgMatches {
                         .short('F')
                         .action(ArgAction::Set)
                         .help("(string): failover state provider"),
+                    Arg::new("fd-as-zone")
+                        .long("fd-as-zone")
+                        .action(ArgAction::SetTrue)
+                        .help(
+                            "Used to insert 'failure_domain' field's value of instances in their 'zone' field.",
+                        ),
                 ]),
             Command::new("init")
                 .about("Init genin and create cluster.genin.yaml configuration")

--- a/src/task/cluster.rs
+++ b/src/task/cluster.rs
@@ -554,9 +554,7 @@ impl Cluster {
     /// Note that method is intended to be called after cluster is spread
     /// - that's it, when there may only be single domain name in instance's `failure_domains`.
     pub fn use_failure_domain_as_zone_for_instances(&mut self) {
-        for host in self.hosts.hosts.iter_mut() {
-            host.use_failure_domain_as_zone()
-        }
+        self.hosts.use_failure_domain_as_zone()
     }
 }
 

--- a/src/task/cluster.rs
+++ b/src/task/cluster.rs
@@ -548,6 +548,16 @@ impl Cluster {
 
         Ok(self)
     }
+
+    /// It will traverse the cluster, replacing every instance's zone with its `failure_domain`.
+    ///
+    /// Note that method is intended to be called after cluster is spread
+    /// - that's it, when there may only be single domain name in instance's `failure_domains`.
+    pub fn use_failure_domain_as_zone_for_instances(&mut self) {
+        for host in self.hosts.hosts.iter_mut() {
+            host.use_failure_domain_as_zone()
+        }
+    }
 }
 
 #[derive(Deserialize)]

--- a/src/task/cluster/hst/v2.rs
+++ b/src/task/cluster/hst/v2.rs
@@ -337,6 +337,12 @@ impl HostV2 {
                 );
                 instance.failure_domains = Vec::new();
             }
+            // if it is the last failure domain binding(in other words, we find the needed place for instance),
+            // keep that failure domain name in the instance and remove others.
+            if instance.failure_domains.is_empty() {
+                instance.failure_domains = vec![self.name.to_string()];
+            }
+
             self.hosts.sort();
             return self.push(instance);
         };
@@ -640,6 +646,18 @@ impl HostV2 {
                 binary_port: self.config.binary_port,
                 ..rhs.config.clone()
             };
+        }
+    }
+
+    /// For every instance that has failure domain available, replace its zone with that domain name.
+    pub fn use_failure_domain_as_zone(&mut self) {
+        for instance in self.instances.iter_mut() {
+            if let Some(failure_domain) = instance.failure_domains.first() {
+                instance.config.zone = Some(failure_domain.clone());
+            }
+        }
+        for sub_host in self.hosts.iter_mut() {
+            sub_host.use_failure_domain_as_zone()
         }
     }
 }

--- a/src/task/cluster/hst/v2.rs
+++ b/src/task/cluster/hst/v2.rs
@@ -325,14 +325,15 @@ impl HostV2 {
         // if we found some name equality between host name and failure domain
         // remove it and push instance
         if let Some(index) = failure_domain_index {
+            let domain_name = instance.failure_domains.remove(index);
             trace!(
-                "removing {} failure domain from bindings in {}",
-                instance.failure_domains.remove(index),
+                "found failure domain {} for {} instance",
+                domain_name,
                 instance.name
             );
             if !self.contains_failure_domains(&instance.failure_domains) {
                 trace!(
-                    "removing all failure domains from bindings in {}",
+                    "cleaning failure domains for instance {}, as no more needed failure domains can be found",
                     instance.name
                 );
                 instance.failure_domains = Vec::new();
@@ -342,6 +343,12 @@ impl HostV2 {
             if instance.failure_domains.is_empty() {
                 instance.failure_domains = vec![self.name.to_string()];
             }
+
+            trace!(
+                "failure domains for {} is: {}",
+                instance.name,
+                instance.failure_domains.join(" ")
+            );
 
             self.hosts.sort();
             return self.push(instance);


### PR DESCRIPTION
Добавляет реализацию флага "--fd-as-zone" для команды build, чтобы можно было использовать failure domain как зону для инстанса
