### PR TITLE
fix: invalid cluster print

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "genin"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genin"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Download and unzip the archive for the desired architecture.
 
 Universal executable:
 ```shell
-curl -sLO https://binary.picodata.io/repository/raw/genin/bin/genin-0.5.3-x86_64-musl.tar.gz
-tar -xvf genin-0.5.3-x86_64-musl.tar.gz ; sudo install genin /usr/local/bin/
+curl -sLO https://binary.picodata.io/repository/raw/genin/bin/genin-0.5.4-x86_64-musl.tar.gz
+tar -xvf genin-0.5.4-x86_64-musl.tar.gz ; sudo install genin /usr/local/bin/
 ```
 
 ---
@@ -84,11 +84,11 @@ sudo yum install -y genin
 2. If you want to install `rpm` packages directly without
 adding our repository.
 ```shell
-sudo rpm -i https://binary.picodata.io/repository/yum/el/8/x86_64/os/genin-0.5.3-1.el8.x86_64.rpm
+sudo rpm -i https://binary.picodata.io/repository/yum/el/8/x86_64/os/genin-0.5.4-1.el8.x86_64.rpm
 ```
 RHEL 7.x, CentOS 7.x
 ```shell
-sudo rpm -i https://binary.picodata.io/repository/yum/el/7/x86_64/os/genin-0.5.3-1.el7.x86_64.rpm
+sudo rpm -i https://binary.picodata.io/repository/yum/el/7/x86_64/os/genin-0.5.4-1.el7.x86_64.rpm
 ```
 
 ---
@@ -116,7 +116,7 @@ sudo apt install -y genin
 
 2. Downloading and installing the package directly:
 ```shell
-curl -sLO https://binary.picodata.io/repository/raw/genin/deb/genin-0.5.3.amd64.deb && sudo dpkg -i genin-0.5.3.amd64.deb
+curl -sLO https://binary.picodata.io/repository/raw/genin/deb/genin-0.5.4.amd64.deb && sudo dpkg -i genin-0.5.4.amd64.deb
 ```
 
 ---
@@ -142,7 +142,7 @@ sudo apt install -y genin
 
 2. Downloading and installing the package directly:
 ```shell
-curl -sLO https://binary.picodata.io/repository/raw/genin/deb/genin-0.5.3.amd64.deb && sudo dpkg -i genin-0.5.3.amd64.deb
+curl -sLO https://binary.picodata.io/repository/raw/genin/deb/genin-0.5.4.amd64.deb && sudo dpkg -i genin-0.5.4.amd64.deb
 ```
 
 ---
@@ -162,8 +162,8 @@ brew install genin
 Use the following command to grab and install Genin in macOS (10.10+) wihtout
 homebrew:
 ```shell
-curl -L https://binary.picodata.io/repository/raw/genin/apple/genin-0.5.3-darwin-amd64.zip -o genin-0.5.3-darwin-amd64.zip
-unzip genin-0.5.3-darwin-amd64.zip -d ~/bin/
+curl -L https://binary.picodata.io/repository/raw/genin/apple/genin-0.5.4-darwin-amd64.zip -o genin-0.5.4-darwin-amd64.zip
+unzip genin-0.5.4-darwin-amd64.zip -d ~/bin/
 ```
 > **Note:** The application can then be found under the `~/bin` directory.
 > Make sure the directory is in your `$PATH`.
@@ -181,8 +181,8 @@ brew install genin@0.3.8
 #### Windows
 Use the following command to grab and install Genin in Windows 7 64 bit or newer:
 ```shell
-curl.exe -L https://binary.picodata.io/repository/raw/genin/windows/genin-0.5.3-darwin-amd64.zip -o genin-0.5.3-windows-amd64.zip
-unzip.exe genin-0.5.3-windows-amd64.zip -d %HOME%/.cargo/bin/
+curl.exe -L https://binary.picodata.io/repository/raw/genin/windows/genin-0.5.4-darwin-amd64.zip -o genin-0.5.4-windows-amd64.zip
+unzip.exe genin-0.5.4-windows-amd64.zip -d %HOME%/.cargo/bin/
 ```
 > **Note:** The application can then be found under the `.cargo/bin` folder inside
 > your user profile folder. Make sure it is in your `%PATH%`.

--- a/README.ru.md
+++ b/README.ru.md
@@ -49,8 +49,8 @@ Genin уже заранее скомпилирован под разные ар�
 
 Универсальный исполняемый файл:
 ```shell
-curl -sLO https://binary.picodata.io/repository/raw/genin/bin/genin-0.5.3-x86_64-musl.tar.gz
-tar -xvf genin-0.5.3-x86_64-musl.tar.gz ; sudo install genin /usr/local/bin/
+curl -sLO https://binary.picodata.io/repository/raw/genin/bin/genin-0.5.4-x86_64-musl.tar.gz
+tar -xvf genin-0.5.4-x86_64-musl.tar.gz ; sudo install genin /usr/local/bin/
 ```
 
 ---
@@ -87,11 +87,11 @@ sudo yum install -y genin
 2. Так же вы можете установить пакет `rpm` напрямую без добавления нашего репозитория.
 RHEL 8.x, CentOS 8.x, Rockylinux 8.x, recent Fedora version
 ```shell
-sudo rpm -i https://binary.picodata.io/repository/yum/el/8/x86_64/os/genin-0.5.3-1.el8.x86_64.rpm
+sudo rpm -i https://binary.picodata.io/repository/yum/el/8/x86_64/os/genin-0.5.4-1.el8.x86_64.rpm
 ```
 RHEL 7.x, CentOS 7.x
 ```shell
-sudo rpm -i https://binary.picodata.io/repository/yum/el/7/x86_64/os/genin-0.5.3-1.el7.x86_64.rpm
+sudo rpm -i https://binary.picodata.io/repository/yum/el/7/x86_64/os/genin-0.5.4-1.el7.x86_64.rpm
 ```
 > **Note:** будьте внимательны, так как при выборе не правильной версии ос могут быть ошибки
 > при установке `rpm`
@@ -118,7 +118,7 @@ sudo apt install -y genin
 
 2. Загрузкой и установкой пакета напрямую:
 ```shell
-curl -sLO https://binary.picodata.io/repository/raw/genin/deb/genin-0.5.3.amd64.deb && sudo dpkg -i genin-0.5.3.amd64.deb
+curl -sLO https://binary.picodata.io/repository/raw/genin/deb/genin-0.5.4.amd64.deb && sudo dpkg -i genin-0.5.4.amd64.deb
 ```
 
 ---
@@ -143,7 +143,7 @@ sudo apt install -y genin
 
 2. Загрузкой и установкой пакета напрямую:
 ```shell
-curl -sLO https://binary.picodata.io/repository/raw/genin/deb/genin-0.5.3.amd64.deb && sudo dpkg -i genin-0.5.3.amd64.deb
+curl -sLO https://binary.picodata.io/repository/raw/genin/deb/genin-0.5.4.amd64.deb && sudo dpkg -i genin-0.5.4.amd64.deb
 ```
 
 ---
@@ -163,8 +163,8 @@ brew install genin
 Для установки без помощи homebrew используйте следующие команды для загрузки и установки
 Genin на macOS (10.10+):
 ```shell
-curl -sLO https://binary.picodata.io/repository/raw/genin/osx/genin-0.5.3-x86_64-macosx.tar.gz
-unzip genin-0.5.3-darwin-amd64.zip -d ~/bin/
+curl -sLO https://binary.picodata.io/repository/raw/genin/osx/genin-0.5.4-x86_64-macosx.tar.gz
+unzip genin-0.5.4-darwin-amd64.zip -d ~/bin/
 ```
 
 ---
@@ -188,8 +188,8 @@ brew install genin@0.3.8
 Используйте следующие команды для скачивания и установки Genin на операционных системах
 Windows 7 64 и новее.
 ```shell
-curl.exe -sLO https://binary.picodata.io/repository/raw/genin/win/genin-0.5.3-win64.zip
-unzip.exe genin-0.5.3-win64.zip -d %HOME%/.cargo/bin/
+curl.exe -sLO https://binary.picodata.io/repository/raw/genin/win/genin-0.5.4-win64.zip
+unzip.exe genin-0.5.4-win64.zip -d %HOME%/.cargo/bin/
 ```
 > **Note:** Genin будет распакован в директорию `.cargo/bin` которая находится в домашнем
 > каталоге важего пользователя. Перед использованием приложения пожалуйста удостоверьтесь
@@ -199,7 +199,7 @@ unzip.exe genin-0.5.3-win64.zip -d %HOME%/.cargo/bin/
 ```
 genin --version
 ```
-Если вы видите сообщение `genin 0.5.3` значит установка прошла успешно.
+Если вы видите сообщение `genin 0.5.4` значит установка прошла успешно.
 
 ---
 ## Руководство по использованию

--- a/src/task/cluster.rs
+++ b/src/task/cluster.rs
@@ -43,6 +43,7 @@ use crate::task::utils::create_file_or_copy;
 use crate::task::vars::InvalidVars;
 
 use super::state::Change;
+use super::{TypeError, DICT};
 
 /// Cluster is a `genin` specific configuration file
 /// ```rust
@@ -470,9 +471,14 @@ impl<'de> Deserialize<'de> for Cluster {
                 },
             }
             .spread()),
-            ClusterHelper::InvalidCluster(_) => Err(serde::de::Error::custom(
-                "Cluster configuration contains errors",
-            )),
+            ClusterHelper::InvalidCluster(value) => {
+                println!(
+                    "Cluster configuration contains errors: {:?}",
+                    serde_yaml::from_value::<InvalidCluster>(value)
+                        .expect("can't fail because it was already parsed into the similiar type")
+                );
+                Err(serde::de::Error::custom("Invalid cluster configuration"))
+            }
         })
     }
 }
@@ -923,7 +929,6 @@ impl HostV2Helper {
     }
 }
 
-#[allow(unused)]
 struct TopologyMemberV1 {
     name: Name,
     count: usize,
@@ -979,16 +984,12 @@ impl<'de> Deserialize<'de> for TopologyMemberV1 {
     }
 }
 
-#[allow(unused)]
 #[derive(Deserialize, Default)]
+#[serde(default)]
 pub struct InvalidCluster {
-    #[serde(default)]
     topology: Value,
-    #[serde(default)]
     hosts: Value,
-    #[serde(default)]
     failover: Value,
-    #[serde(default)]
     vars: Value,
 }
 
@@ -1058,7 +1059,10 @@ impl std::fmt::Debug for InvalidCluster {
                 ))?;
             }
             _ => {
-                formatter.write_str("Failover must be a mapping".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\nfailover: {}",
+                    self.failover.type_error(DICT).as_error()
+                ))?;
             }
         }
 
@@ -1072,8 +1076,10 @@ impl std::fmt::Debug for InvalidCluster {
                 ))?;
             }
             _ => {
-                formatter.write_str("\nvars: ")?;
-                formatter.write_str("Vars must be a mapping".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\nvars: {}",
+                    self.vars.type_error(DICT).as_error()
+                ))?;
             }
         }
 

--- a/src/task/cluster/hst/v2.rs
+++ b/src/task/cluster/hst/v2.rs
@@ -1088,15 +1088,12 @@ impl<'a> From<DomainMember> for Cow<'a, str> {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
 pub struct IPSubnet(Vec<IpAddr>);
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
+#[serde(default)]
 pub struct InvalidHostV2 {
-    #[serde(skip)]
     pub offset: String,
-    #[serde(default)]
     name: Value,
-    #[serde(default)]
     config: Value,
-    #[serde(default)]
     hosts: Value,
 }
 
@@ -1177,19 +1174,15 @@ impl fmt::Debug for InvalidHostV2 {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
+#[serde(default)]
 pub struct InvalidHostV2Config {
     #[serde(skip)]
     offset: String,
-    #[serde(default)]
     pub http_port: Value,
-    #[serde(default)]
     pub binary_port: Value,
-    #[serde(default)]
     pub address: Value,
-    #[serde(default)]
     pub distance: Value,
-    #[serde(default)]
     pub additional_config: Value,
 }
 

--- a/src/task/cluster/snapshots/genin__task__cluster__test__missing_host_fields.snap
+++ b/src/task/cluster/snapshots/genin__task__cluster__test__missing_host_fields.snap
@@ -2,7 +2,7 @@
 source: src/task/cluster/test.rs
 expression: uncolorize(result)
 ---
-Err(Cluster configuration contains errors(Ok(
+Err(Invalid cluster configuration(Ok(
 ---
 topology: "Missing field 'topology'"
 hosts:
@@ -14,5 +14,5 @@ hosts:
     hosts: 
       - name: server-10
       - name: server-11
-vars: "Vars must be a mapping"
+vars: "Expected type Dict got Null"
 )))

--- a/src/task/cluster/snapshots/genin__task__cluster__test__missing_main_fields_err.snap
+++ b/src/task/cluster/snapshots/genin__task__cluster__test__missing_main_fields_err.snap
@@ -2,9 +2,9 @@
 source: src/task/cluster/test.rs
 expression: uncolorize(result)
 ---
-Err(Cluster configuration contains errors(Ok(
+Err(Invalid cluster configuration(Ok(
 ---
 topology: "Missing field 'topology'"
 hosts: "Missing field 'hosts'"
-vars: "Vars must be a mapping"
+vars: "Expected type Dict got Null"
 )))

--- a/src/task/cluster/snapshots/genin__task__cluster__test__missing_toplogy_set_fields.snap
+++ b/src/task/cluster/snapshots/genin__task__cluster__test__missing_toplogy_set_fields.snap
@@ -2,7 +2,7 @@
 source: src/task/cluster/test.rs
 expression: uncolorize(result)
 ---
-Err(Cluster configuration contains errors(Ok(
+Err(Invalid cluster configuration(Ok(
 ---
 topology: 
   - name: "Missing field 'name'"
@@ -28,5 +28,5 @@ topology:
     roles: 
       - value
 hosts: "Missing field 'hosts'"
-vars: "Vars must be a mapping"
+vars: "Expected type Dict got Null"
 )))

--- a/src/task/cluster/snapshots/genin__task__cluster__test__placeholders_in_config.snap
+++ b/src/task/cluster/snapshots/genin__task__cluster__test__placeholders_in_config.snap
@@ -2,7 +2,7 @@
 source: src/task/cluster/test.rs
 expression: uncolorize(result)
 ---
-Err(Cluster configuration contains errors(Err(
+Err(Invalid cluster configuration(Err(
 
 ---
 topology:

--- a/src/task/cluster/topology.rs
+++ b/src/task/cluster/topology.rs
@@ -485,7 +485,7 @@ impl std::fmt::Debug for InvalidTopologySet {
             }
             _ => {
                 formatter.write_fmt(format_args!(
-                    "    replication_factor: {}",
+                    "\n    replication_factor: {}",
                     self.replication_factor.type_error(NUMBER).as_error()
                 ))?;
             }

--- a/src/task/flv.rs
+++ b/src/task/flv.rs
@@ -11,7 +11,7 @@ use crate::{
     DEFAULT_STATEBOARD_PORT,
 };
 
-use super::{cluster::hst::v2::Address, AsError};
+use super::{cluster::hst::v2::Address, AsError, TypeError, LIST, NUMBER, STRING};
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 /// Failover enum
@@ -718,16 +718,22 @@ pub struct InvalidETCD2 {
 
 impl fmt::Debug for InvalidETCD2 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("\n    prefix: ")?;
         match &self.prefix {
             Value::Null => {
-                formatter.write_str("Missing field 'prefix'".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n    prefix: {}",
+                    "Missing field 'prefix'".as_error()
+                ))?;
             }
             Value::String(prefix) => {
+                formatter.write_str("\n    prefix: ")?;
                 formatter.write_str(prefix)?;
             }
             _ => {
-                formatter.write_str("Field 'prefix' must be a String".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n    prefix: {}",
+                    self.prefix.type_error(STRING).as_error()
+                ))?;
             }
         }
 
@@ -737,17 +743,22 @@ impl fmt::Debug for InvalidETCD2 {
                 formatter.write_str(lock_delay.to_string().as_str())?;
             }
             _ => {
-                formatter.write_str("\n    lock_delay: ")?;
-                formatter.write_str("Field 'lock_delay' must be a Number".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n    lock_delay: {}",
+                    self.lock_delay.type_error(NUMBER).as_error()
+                ))?;
             }
         }
 
-        formatter.write_str("\n    endpoints:")?;
         match &self.endpoints {
             Value::Null => {
-                formatter.write_str("Missing field 'endpoints'".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n    endpoints: {}",
+                    "Missing field 'endpoints'".as_error().as_str()
+                ))?;
             }
             Value::Sequence(seq) => {
+                formatter.write_str("\n    endpoints:")?;
                 for endpoint in seq {
                     if let Ok(uri) = serde_yaml::from_value::<UriWithProtocol>(endpoint.clone()) {
                         formatter.write_str(format!("\n      - {uri}").as_str())?;
@@ -758,7 +769,10 @@ impl fmt::Debug for InvalidETCD2 {
                 }
             }
             _ => {
-                formatter.write_str("Field 'lock_delay' must be a Sequence".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n    endpoints: {}",
+                    self.endpoints.type_error(LIST).as_error()
+                ))?;
             }
         }
 
@@ -768,8 +782,10 @@ impl fmt::Debug for InvalidETCD2 {
                 formatter.write_str(username)?;
             }
             _ => {
-                formatter.write_str("\n    username: ")?;
-                formatter.write_str("Field 'username' must be a String".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n    username: {}",
+                    self.username.type_error(STRING).as_error()
+                ))?;
             }
         }
 
@@ -779,8 +795,10 @@ impl fmt::Debug for InvalidETCD2 {
                 formatter.write_str(password)?;
             }
             _ => {
-                formatter.write_str("\n    password: ")?;
-                formatter.write_str("Field 'password' must be a String".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n    password: {}",
+                    self.username.type_error(STRING).as_error()
+                ))?;
             }
         }
         Ok(())
@@ -802,16 +820,22 @@ impl fmt::Debug for InvalidStateboardParams {
             formatter.write_str("Invalid Uri".as_error().as_str())?;
         }
 
-        formatter.write_str("\n      password: ")?;
         match &self.password {
             Value::Null => {
-                formatter.write_str("Missing field 'password'".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n      password: {}",
+                    "Missing field 'password'".as_error()
+                ))?;
             }
             Value::String(password) => {
+                formatter.write_str("\n      password: ")?;
                 formatter.write_str(password)?;
             }
             _ => {
-                formatter.write_str("Field 'password' must be a String".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n      password: {}",
+                    self.password.type_error(STRING).as_error()
+                ))?;
             }
         }
 

--- a/src/task/flv/snapshots/genin__task__flv__test__invalid_failover-8.snap
+++ b/src/task/flv/snapshots/genin__task__flv__test__invalid_failover-8.snap
@@ -7,9 +7,9 @@ expression: uncolorize(invalid_v1)
   state_provider: etcd2
   etcd2_params: 
     prefix: /cartridge
-    lock_delay: "Field 'lock_delay' must be a Number"
+    lock_delay: "Expected type Number got String"
     endpoints:
       - http://172.20.73.12:2379
       - "InvalidUri"
-    username: "Field 'username' must be a String"
-    password: "Field 'password' must be a String"
+    username: "Expected type String got Number"
+    password: "Expected type String got Number"

--- a/src/task/flv/snapshots/genin__task__flv__test__invalid_failover-9.snap
+++ b/src/task/flv/snapshots/genin__task__flv__test__invalid_failover-9.snap
@@ -7,4 +7,4 @@ expression: uncolorize(invalid_v1)
   state_provider: stateboard
   stateboard_params: 
       uri: 192.168.16.11:4401
-      password: "Field 'password' must be a String"
+      password: "Expected type String got Number"

--- a/src/task/vars.rs
+++ b/src/task/vars.rs
@@ -6,7 +6,7 @@ use serde_yaml::Value;
 
 use super::{
     flv::{Failover, FailoverVariants, Mode, StateProvider},
-    AsError,
+    AsError, TypeError, BOOL, DICT, STRING,
 };
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
@@ -102,8 +102,10 @@ impl fmt::Debug for InvalidVars {
                 formatter.write_str(ansible_user.as_str())?;
             }
             _ => {
-                formatter.write_str("\n  ansible_user: ")?;
-                formatter.write_str("Field 'ansible_user' must be a String".as_error().as_str())?;
+                formatter.write_fmt(format_args!(
+                    "\n  ansible_user: {}",
+                    self.ansible_user.type_error(STRING).as_error()
+                ))?;
             }
         }
 
@@ -114,12 +116,10 @@ impl fmt::Debug for InvalidVars {
                 formatter.write_str(ansible_password.as_str())?;
             }
             _ => {
-                formatter.write_str("\n  ansible_password: ")?;
-                formatter.write_str(
-                    "Field 'ansible_password' must be a String"
-                        .as_error()
-                        .as_str(),
-                )?;
+                formatter.write_fmt(format_args!(
+                    "\n  ansible_password: {}",
+                    self.ansible_password.type_error(STRING).as_error()
+                ))?;
             }
         }
 
@@ -130,12 +130,10 @@ impl fmt::Debug for InvalidVars {
                 formatter.write_str(cartridge_cluster_cookie.as_str())?;
             }
             _ => {
-                formatter.write_str("\n  cartridge_cluster_cookie: ")?;
-                formatter.write_str(
-                    "Field 'cartridge_cluster_cookie' must be a String"
-                        .as_error()
-                        .as_str(),
-                )?;
+                formatter.write_fmt(format_args!(
+                    "\n  cartridge_cluster_cookie: {}",
+                    self.cartridge_cluster_cookie.type_error(STRING).as_error()
+                ))?;
             }
         }
 
@@ -146,12 +144,10 @@ impl fmt::Debug for InvalidVars {
                 formatter.write_str(cartridge_package_path.as_str())?;
             }
             _ => {
-                formatter.write_str("\n  cartridge_package_path: ")?;
-                formatter.write_str(
-                    "Field 'cartridge_package_path' must be a String"
-                        .as_error()
-                        .as_str(),
-                )?;
+                formatter.write_fmt(format_args!(
+                    "\n  cartridge_package_path: {}",
+                    self.cartridge_package_path.type_error(STRING).as_error()
+                ))?;
             }
         }
 
@@ -162,12 +158,10 @@ impl fmt::Debug for InvalidVars {
                 formatter.write_str(cartridge_bootstrap_vshard.to_string().as_str())?;
             }
             _ => {
-                formatter.write_str("\n  cartridge_bootstrap_vshard: ")?;
-                formatter.write_str(
-                    "Field 'cartridge_bootstrap_vshard' must be a Bool"
-                        .as_error()
-                        .as_str(),
-                )?;
+                formatter.write_fmt(format_args!(
+                    "\n  cartridge_bootstrap_vshard: {}",
+                    self.cartridge_bootstrap_vshard.type_error(BOOL).as_error()
+                ))?;
             }
         }
 
@@ -182,12 +176,10 @@ impl fmt::Debug for InvalidVars {
                 }
             }
             _ => {
-                formatter.write_str("\n  cartridge_failover_params: ")?;
-                formatter.write_str(
-                    "Field 'cartridge_failover_params' must be a Dict"
-                        .as_error()
-                        .as_str(),
-                )?;
+                formatter.write_fmt(format_args!(
+                    "\n  cartridge_failover_params: {}",
+                    self.cartridge_failover_params.type_error(DICT).as_error()
+                ))?;
             }
         }
 
@@ -197,12 +189,10 @@ impl fmt::Debug for InvalidVars {
                 print_value_recursive(formatter, "\n    ", another_fields)?;
             }
             _ => {
-                formatter.write_str("\n  another_fields: ")?;
-                formatter.write_str(
-                    "Field 'another_fields' must be a Mapping"
-                        .as_error()
-                        .as_str(),
-                )?;
+                formatter.write_fmt(format_args!(
+                    "\n  another_fields: {}",
+                    self.another_fields.type_error(DICT).as_error()
+                ))?;
             }
         }
 

--- a/src/task/vars/snapshots/genin__task__vars__test__invalid_vars.snap
+++ b/src/task/vars/snapshots/genin__task__vars__test__invalid_vars.snap
@@ -3,9 +3,9 @@ source: src/task/vars/test.rs
 expression: uncolorize(vars)
 ---
 
-  ansible_user: "Field 'ansible_user' must be a String"
-  ansible_password: "Field 'ansible_password' must be a String"
-  cartridge_cluster_cookie: "Field 'cartridge_cluster_cookie' must be a String"
-  cartridge_package_path: "Field 'cartridge_package_path' must be a String"
-  cartridge_bootstrap_vshard: "Field 'cartridge_bootstrap_vshard' must be a Bool"
-  cartridge_failover_params: "Field 'cartridge_failover_params' must be a Dict"
+  ansible_user: "Expected type String got Number"
+  ansible_password: "Expected type String got Bool"
+  cartridge_cluster_cookie: "Expected type String got Number"
+  cartridge_package_path: "Expected type String got Dict"
+  cartridge_bootstrap_vshard: "Expected type Bool got Number"
+  cartridge_failover_params: "Expected type Dict got List"

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -415,3 +415,24 @@ fn upgrade_consistency_100_times() {
         insta::assert_display_snapshot!("consistency_100_times", consistency_100_times);
     }
 }
+
+#[test]
+fn build_invalid_config() {
+    cleanup_test_dir("tests/.build_invalid_config");
+
+    let output = Command::new(format!(
+        "{}/target/debug/genin",
+        std::env::var("CARGO_MANIFEST_DIR").unwrap()
+    ))
+    .arg("build")
+    .arg("-s")
+    .arg("tests/resources/cluster-invalid.genin.yml")
+    .arg("-o")
+    .arg("tests/.build_invalid_config/inventory.yml")
+    .output()
+    .expect("Failed to execute command");
+
+    let build_invalid_config = build_result_from_output(output);
+
+    insta::assert_display_snapshot!(build_invalid_config);
+}

--- a/tests/resources/cluster-invalid.genin.yml
+++ b/tests/resources/cluster-invalid.genin.yml
@@ -1,0 +1,87 @@
+---
+# List of replicasets as an array
+topology:
+    # How many masters we want, by default equal 1
+  - replicasets_count: "2"
+    # Array of roles for this instance
+    roles:
+      - router
+      - failover-coordinator
+  - name: [ "storage" ]
+    # How many masters we want, by default equal 1
+    replicasets_count: 2
+    # Number of replicas in replicaset, default 0
+    replication_factor: "tree"
+    # Array of roles for this instance
+    roles:
+      storage: true
+      failover-coordinator: false
+# List of regions, datacenters, and servers
+hosts:
+  - name: datacenter-1
+    # Config with arbitrary key-values pairs
+    config:
+      # Specify http port to start counting from
+      http_port: 506023
+      # Specify binary port to start counting from
+      binary_port: "3031"
+    # List of regions, datacenters, and servers
+    hosts:
+      - name: server-1
+        # Config with arbitrary key-values pairs
+        config:
+          # Specify http port to start counting from
+          http_port: 
+            - 8081
+            - 8082
+          # Specify binary port to start counting from
+          binary_port: 3031
+          # Host or instance address (maybe IP or URI)
+          address: 192.168.16.11
+      - name: server-2
+        # Config with arbitrary key-values pairs
+        config:
+          # Specify http port to start counting from
+          http_port: 8081
+          # Specify binary port to start counting from
+          binary_port: 3031
+          # Host or instance address (maybe IP or URI)
+          address: ~
+        # Config with arbitrary key-values pairs
+      - config:
+          # Specify http port to start counting from
+          http_port: 8081
+          # Specify binary port to start counting from
+          binary_port: 3031
+          # Host or instance address (maybe IP or URI)
+          address: 1000
+          # Additional parameters to be added to the host config
+          additional_config: 
+            - HOST: localhost
+            - PORT: 3000
+# Failover management options
+failover:
+  # Failover mode (stateful, eventual, disabled)
+  mode: stateful
+  # What is serve failover (stateboard, stateful)
+  state_provider: stateboard
+  # Params for chosen in state_provider failover type
+  stateboard_params:
+    # Uri on which the stateboard will be available
+    uri: "192.168.16.11"
+    # Stateboard password
+    password: 123
+# Vars similar to those configured in the cartridge inventory
+vars:
+  # Username under which the ansible will connect to the servers
+  ansible_user: ansible
+  # Ansible user password
+  ansible_password: 123
+  # Application name
+  cartridge_app_name: myapp
+  # Cookie for connecting to the administrative console of the instances
+  cartridge_cluster_cookie: myapp-cookie
+  # Path to the application package
+  cartridge_package_path: /tmp/myapp.rpm
+  # Indicates if vshard must be bootstrapped on the cluster
+  cartridge_bootstrap_vshard: "true"

--- a/tests/snapshots/r#mod__build_invalid_config.snap
+++ b/tests/snapshots/r#mod__build_invalid_config.snap
@@ -1,0 +1,52 @@
+---
+source: tests/mod.rs
+expression: build_invalid_config
+---
+Cluster configuration contains errors: 
+---
+topology: 
+  - name: "Missing field 'name'"
+    replicasets_count: "Expected type Number got String"
+    roles: 
+      - router
+      - failover-coordinator
+  - name: "Expected type String got List"
+    replicasets_count: 2
+    replication_factor: "Expected type Number got String"
+    roles: "Expected type List got Dict"
+hosts:
+  - name: datacenter-1
+    config: 
+      http_port: "Not in range 0..65535"
+      binary_port: "Expected type Number got String"
+    hosts: 
+      - name: server-1
+        config: 
+          http_port: "Expected type Number got List"
+          binary_port: 3031
+          address: 192.168.16.11
+      - name: server-2
+        config: 
+          http_port: 8081
+          binary_port: 3031
+      - name: "Missing field 'name'"
+        config: 
+          http_port: 8081
+          binary_port: 3031
+          address: "Expected type String got Number"
+          additional_config: "Expected type Dict got List"
+failover: 
+  mode: stateful
+  state_provider: stateboard
+  stateboard_params: 
+      uri: "Invalid Uri"
+      password: "Expected type String got Number"
+vars: 
+  ansible_user: ansible
+  ansible_password: "Expected type String got Number"
+  cartridge_cluster_cookie: myapp-cookie
+  cartridge_package_path: /tmp/myapp.rpm
+  cartridge_bootstrap_vshard: "Expected type Bool got String"
+
+Error: Serde(Message("Invalid cluster configuration", None))
+


### PR DESCRIPTION
After refactoring the `genin upgrade` and adding a new state entity,
parsing errors in the configuration was broken. This patch fixes bugs
and also brings invalid config parsing messages to a better format.